### PR TITLE
Allow build with Visual Studio (at least 2010)

### DIFF
--- a/core/dcauth.cpp
+++ b/core/dcauth.cpp
@@ -27,7 +27,7 @@
 #include "util/asserter.h"
 #include <QDateTime>
 
-#ifdef Q_OS_MAC
+#if defined(Q_OS_MAC) || defined(Q_OS_WIN)
 #define CLOCK_REALTIME 0
 #endif
 

--- a/core/settings.cpp
+++ b/core/settings.cpp
@@ -27,7 +27,9 @@
 #include <QSettings>
 #include <QDebug>
 #include <fcntl.h>
+#if !defined(Q_OS_WIN)
 #include <unistd.h>
+#endif
 
 #include <openssl/bn.h>
 

--- a/secret/decryptedmessagebuilder.cpp
+++ b/secret/decryptedmessagebuilder.cpp
@@ -6,9 +6,9 @@ DecryptedMessageBuilder::DecryptedMessageBuilder(qint32 layer) : mLayer(layer) {
 
 QByteArray DecryptedMessageBuilder::generateRandomBytes() {
     qint32 n = 15 + 4 * (lrand48() % 3);
-    char rnd[n];
-    Utils::randomBytes(rnd, n);
-    QByteArray randomBytes(rnd);
+    QScopedArrayPointer<char> rnd(new char[n]);
+    Utils::randomBytes(rnd.data(), n);
+    QByteArray randomBytes(rnd.data());
     return randomBytes;
 }
 

--- a/util/cryptoutils.cpp
+++ b/util/cryptoutils.cpp
@@ -285,24 +285,24 @@ QByteArray CryptoUtils::encryptFilePart(const QByteArray &partBytes, uchar *key,
     uchar *buffer = (uchar *)partBytes.constData();
     // Use an output buffer for not to modify original one.
     // Max size of the output buffer, included padding, will be length + 15
-    uchar out[length + 15];
-    memcpy(out, buffer, length);
+    QScopedArrayPointer<uchar> out(new uchar[length + 15]);
+    memcpy(out.data(), buffer, length);
 
     // in case this part length % 0xF != 0, it means is the last part and we must pad the size to match AES block size (16)
     qint32 paddedSize = length;
     if (length & 15) {
         paddedSize = (length + 15) & -16;
         if (length < paddedSize) {
-            RAND_pseudo_bytes(out + length, paddedSize - length);
+            RAND_pseudo_bytes(out.data() + length, paddedSize - length);
         }
     }
 
     AES_KEY aesKey;
     AES_set_encrypt_key(key, 256, &aesKey);
-    AES_ige_encrypt(out, out, paddedSize, &aesKey, iv, AES_ENCRYPT);
+    AES_ige_encrypt(out.data(), out.data(), paddedSize, &aesKey, iv, AES_ENCRYPT);
     memset(&aesKey, 0, sizeof(aesKey));
 
-    return QByteArray((char *)out, paddedSize);
+    return QByteArray((char *)out.data(), paddedSize);
 }
 
 QByteArray CryptoUtils::decryptFilePart(const QByteArray &partBytes, uchar *key, uchar *iv) {

--- a/util/utils.cpp
+++ b/util/utils.cpp
@@ -51,6 +51,75 @@ int clock_gettime(int /*clk_id*/, struct timespec* t) {
     t->tv_nsec = now.tv_usec * 1000;
     return 0;
 }
+#else if Q_OS_WIN
+//clock_gettime is not implemented on Win
+// took from https://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows
+
+struct timespec {
+    long int tv_sec;    /* Seconds.  */
+    long int tv_nsec;   /* Nanoseconds.  */
+};
+
+LARGE_INTEGER getFILETIMEoffset()
+{
+    SYSTEMTIME s;
+    FILETIME f;
+    LARGE_INTEGER t;
+
+    s.wYear = 1970;
+    s.wMonth = 1;
+    s.wDay = 1;
+    s.wHour = 0;
+    s.wMinute = 0;
+    s.wSecond = 0;
+    s.wMilliseconds = 0;
+    SystemTimeToFileTime(&s, &f);
+    t.QuadPart = f.dwHighDateTime;
+    t.QuadPart <<= 32;
+    t.QuadPart |= f.dwLowDateTime;
+    return (t);
+}
+
+int clock_gettime(int X, struct timespec *ts)
+{
+    LARGE_INTEGER           t;
+    FILETIME                f;
+    double                  nanoseconds;
+    static LARGE_INTEGER    offset;
+    static double           frequencyToNanoseconds;
+    static int              initialized = 0;
+    static BOOL             usePerformanceCounter = 0;
+
+    if (!initialized) {
+        LARGE_INTEGER performanceFrequency;
+        initialized = 1;
+        usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
+        if (usePerformanceCounter) {
+            QueryPerformanceCounter(&offset);
+            frequencyToNanoseconds = (double)performanceFrequency.QuadPart / 1000.;
+        } else {
+            offset = getFILETIMEoffset();
+            frequencyToNanoseconds = 0.010;
+        }
+    }
+    if (usePerformanceCounter) {
+        QueryPerformanceCounter(&t);
+    }
+    else {
+        GetSystemTimeAsFileTime(&f);
+        t.QuadPart = f.dwHighDateTime;
+        t.QuadPart <<= 32;
+        t.QuadPart |= f.dwLowDateTime;
+    }
+
+    t.QuadPart -= offset.QuadPart;
+    nanoseconds = (double)t.QuadPart / frequencyToNanoseconds;
+    t.QuadPart = nanoseconds;
+    ts->tv_sec = t.QuadPart / 1000000000;
+    ts->tv_nsec = t.QuadPart % 1000000000;
+
+    return (0);
+}
 #endif
 
 Utils::Utils(QObject *parent) :
@@ -287,9 +356,9 @@ BIGNUM *Utils::bytesToBignum(const QByteArray &bytes) {
 
 QByteArray Utils::bignumToBytes(BIGNUM *bignum) {
     qint32 length = BN_num_bytes(bignum);
-    uchar data[length];
-    BN_bn2bin(bignum, data);
-    return QByteArray((char *)data, length);
+    QScopedArrayPointer<uchar> data(new uchar[length]);
+    BN_bn2bin(bignum, data.data());
+    return QByteArray((char *)data.data(), length);
 }
 
 qint64 Utils::getKeyFingerprint(uchar *sharedKey) {


### PR DESCRIPTION
- implemented clock_gettime for Windows
- used QScopedArrayPointer instead of static arrays
