### PR TITLE
Fixed compiler warning

### DIFF
--- a/core/dcauth.cpp
+++ b/core/dcauth.cpp
@@ -260,7 +260,7 @@ void DCAuth::processDHAnswer(InboundPkt &inboundPkt) {
 
     mAsserter.check(l >= 250 && l <= 256);
     mAsserter.check(BN_bn2bin (&auth_key_num, (uchar *)m_dc->authKey()));
-    memset (m_dc->authKey() + l, 0, 256 - l);
+    Utils::secureZeroMemory (m_dc->authKey() + l, 0, 256 - l);
     BN_free (dh_power);
     BN_free (&auth_key_num);
     BN_free (&dh_g);

--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -6,9 +6,12 @@ TARGET = qtelegram-ae
 TEMPLATE = lib
 DEFINES += LIBQTELEGRAM_LIBRARY
 
+INCLUDEPATH += ./
+
 win32 {
     LIBS += -LD:/Projects/cutegram-deps/lib -lssleay32 -lcrypto -lz
     INCLUDEPATH += D:/Projects/cutegram-deps/include
+    DEFINES += ZLIB_WINAPI
     DESTDIR = D:/Projects/build/Cutegram-Desktop_Qt_5_4_0_MinGW_32bit-Release/build
 } else {
 macx {

--- a/secret/decrypter.cpp
+++ b/secret/decrypter.cpp
@@ -18,6 +18,7 @@
 #include "decrypter.h"
 #include "util/constants.h"
 #include "util/tlvalues.h"
+#include "util/utils.h"
 #include "core/settings.h"
 #include <openssl/sha.h>
 #include <openssl/aes.h>
@@ -55,7 +56,7 @@ DecryptedMessage Decrypter::decryptEncryptedData(qint64 randomId, const QByteArr
     m_buffer = mBufferPtr.data();
     memcpy(m_buffer, bytes.data(), m_length);
 
-    if (!(m_length & 15) == 8) {
+    if (!((m_length & 15) == 8)) {
         qCWarning(TG_SECRET_DECRYPTER) << "Received packet doesn't satisfy length rule (!(length & 0xF) == 1000)";
         return DecryptedMessage();
     }
@@ -235,7 +236,7 @@ QByteArray Decrypter::decryptEncryptedMessage() {
     AES_KEY aesKey;
     AES_set_decrypt_key(key, 256, &aesKey);
     AES_ige_encrypt((uchar *)m_inPtr, (uchar *)m_inPtr, bufferLength, &aesKey, iv, 0);
-    memset(&aesKey, 0, sizeof (aesKey));
+    Utils::secureZeroMemory(&aesKey, 0, sizeof(aesKey));
 
     qint32 x = prefetchInt();
     if (x < 0 || (x & 3)) {

--- a/secret/encrypter.cpp
+++ b/secret/encrypter.cpp
@@ -291,7 +291,7 @@ qint32 *Encrypter::encryptDecryptedMessage () {
     AES_KEY aesKey;
     AES_set_encrypt_key(key, 256, &aesKey);
     AES_ige_encrypt((uchar *)mEncrPtr, (uchar *)mEncrPtr, 4 * (mEncrEnd - mEncrPtr), &aesKey, iv, 1);
-    memset(&aesKey, 0, sizeof (aesKey));
+    Utils::secureZeroMemory(&aesKey, 0, sizeof(aesKey));
 
     return msgKey;
 }

--- a/util/cryptoutils.cpp
+++ b/util/cryptoutils.cpp
@@ -98,7 +98,7 @@ void CryptoUtils::initAESUnAuth (const char serverNonce[16], const char hiddenCl
     } else {
         AES_set_decrypt_key (aes_key_raw, 32*8, &aes_key);
     }
-    memset (aes_key_raw, 0, sizeof (aes_key_raw));
+    Utils::secureZeroMemory (aes_key_raw, 0, sizeof (aes_key_raw));
 }
 
 void CryptoUtils::initAESAuth (char authKey[192], char msgKey[16], qint32 encrypt) {
@@ -141,7 +141,7 @@ void CryptoUtils::initAESAuth (char authKey[192], char msgKey[16], qint32 encryp
     } else {
         AES_set_decrypt_key (aes_key_raw, 32*8, &aes_key);
     }
-    memset (aes_key_raw, 0, sizeof (aes_key_raw));
+    Utils::secureZeroMemory (aes_key_raw, 0, sizeof (aes_key_raw));
 }
 
 qint32 CryptoUtils::padAESEncrypt (const char *from, qint32 fromLen, char *to, qint32 size) {
@@ -300,7 +300,7 @@ QByteArray CryptoUtils::encryptFilePart(const QByteArray &partBytes, uchar *key,
     AES_KEY aesKey;
     AES_set_encrypt_key(key, 256, &aesKey);
     AES_ige_encrypt(out.data(), out.data(), paddedSize, &aesKey, iv, AES_ENCRYPT);
-    memset(&aesKey, 0, sizeof(aesKey));
+    Utils::secureZeroMemory(&aesKey, 0, sizeof(aesKey));
 
     return QByteArray((char *)out.data(), paddedSize);
 }
@@ -313,7 +313,7 @@ QByteArray CryptoUtils::decryptFilePart(const QByteArray &partBytes, uchar *key,
     AES_KEY aesKey;
     AES_set_decrypt_key(key, 256, &aesKey);
     AES_ige_encrypt(buffer, buffer, length, &aesKey, iv, AES_DECRYPT);
-    memset(&aesKey, 0, sizeof(aesKey));
+    Utils::secureZeroMemory(&aesKey, 0, sizeof(aesKey));
 
     return QByteArray::fromRawData((char *)buffer, length);
 }

--- a/util/utils.cpp
+++ b/util/utils.cpp
@@ -241,6 +241,20 @@ void Utils::freeSecure(void *ptr, qint32 size) {
     free (ptr);
 }
 
+void Utils::secureZeroMemory(void *dst, int val, size_t count) {
+#if defined(Q_OS_WIN)
+    Q_UNUSED(val);
+    RtlSecureZeroMemory(dst, count);
+#else
+    // TODO: maybe we should use memset_s ?
+
+    volatile unsigned char *p = dst; 
+    while (count--) 
+        *p++ = val; 
+
+#endif
+}
+
 RSA *Utils::rsaLoadPublicKey(const QString &publicKeyName) {
     RSA *pubKey = NULL;
     FILE *f = fopen (publicKeyName.toLocal8Bit().data(), "r");

--- a/util/utils.cpp
+++ b/util/utils.cpp
@@ -248,7 +248,7 @@ void Utils::secureZeroMemory(void *dst, int val, size_t count) {
 #else
     // TODO: maybe we should use memset_s ?
 
-    volatile unsigned char *p = dst; 
+    volatile unsigned char *p = (unsigned char *)dst; 
     while (count--) 
         *p++ = val; 
 

--- a/util/utils.cpp
+++ b/util/utils.cpp
@@ -80,7 +80,7 @@ LARGE_INTEGER getFILETIMEoffset()
     return (t);
 }
 
-int clock_gettime(int X, struct timespec *ts)
+int clock_gettime(int /*X*/, struct timespec *ts)
 {
     LARGE_INTEGER           t;
     FILETIME                f;

--- a/util/utils.h
+++ b/util/utils.h
@@ -61,6 +61,7 @@ public:
     static void ensure(qint32 r);
     static void ensurePtr(void *p);
     static void freeSecure (void *ptr, qint32 size);
+    static void secureZeroMemory(void *dst, int val, size_t count);
 
     static void *talloc(size_t size);
     static qint32 tinflate (void *input, qint32 ilen, void *output, qint32 olen);


### PR DESCRIPTION
Also used secure way to zero memory (due to: The compiler could delete the 'memset' function call)

http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1381.pdf
