### PR TITLE
Make it possible to specify full path for libraries (e.g. /usr/lib or…

### DIFF
--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -176,6 +176,10 @@ INSTALL_HEADERS = $$HEADERS
 include(qmake/headerinstall.pri)
 
 target = $$TARGET
-target.path = $$PREFIX/lib/$$LIB_PATH
+isEmpty(LIBDIR) {
+    target.path = $$PREFIX/lib/$$LIB_PATH
+} else {
+    target.path = $$LIBDIR
+}
 
 INSTALLS += target


### PR DESCRIPTION
… /usr/lib64)

Red Hat based distros use /usr/lib{,64}, not /usr/lib/{i386,x86_64}-linux-gnu.
With this modification I can use the following command in my spec file:

```
qmake PREFIX=%{buildroot}%{_prefix} LIBDIR=%{buildroot}%{_libdir}
```

Signed-off-by: Sander Lepik sander@lepik.eu
