### PR TITLE
Fix session server error -1.

### DIFF
--- a/core/session.cpp
+++ b/core/session.cpp
@@ -92,7 +92,7 @@ void Session::processConnected() {
 void Session::processRpcAnswer(QByteArray response) {
     qint32 len = response.length();
 
-    qCDebug(TG_CORE_SESSION) << "connection #" << socketDescriptor() << "received rpc answer" << op << "with" << len << "content bytes by session" << QString::number(m_sessionId, 16);
+    qCDebug(TG_CORE_SESSION) << "connection #" << socketDescriptor() << "received rpc answer with" << len << "content bytes by session" << QString::number(m_sessionId, 16);
 
     InboundPkt p(response.data(), len);
     processRpcMessage(p);

--- a/core/session.cpp
+++ b/core/session.cpp
@@ -90,20 +90,12 @@ void Session::processConnected() {
 }
 
 void Session::processRpcAnswer(QByteArray response) {
-
-    qint32 op;
-    peekIn(&op, 4);
     qint32 len = response.length();
 
     qCDebug(TG_CORE_SESSION) << "connection #" << socketDescriptor() << "received rpc answer" << op << "with" << len << "content bytes by session" << QString::number(m_sessionId, 16);
 
     InboundPkt p(response.data(), len);
-
-    if (op < 0 && op >= -999) {
-        qCDebug(TG_CORE_SESSION) << "server error" << op;
-    } else {
-        processRpcMessage(p);
-    }
+    processRpcMessage(p);
 }
 
 void Session::processRpcMessage(InboundPkt &inboundPkt) {


### PR DESCRIPTION
The removed implemented behavior is not documented in Telegram protocol nor used by Android app, for instance, see [here](https://github.com/DrKLO/Telegram/blob/master/TMessagesProj/src/main/java/org/telegram/messenger/HandshakeAction.java#L635). It is causing erratic behavior during sign in process and has been confirmed the invalid behavior is no longer reproducible with that fix applied. I am able to reproduce the problem without the fix.
