### PR TITLE
Install using qt provided paths avoiding the need to insert extras variables

### DIFF
--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -165,7 +165,6 @@ HEADERS += \
     types/config.h \
     types/accountpassword.h \
     types/affectedmessages.h
-}
 
 isEmpty(PREFIX) {
     PREFIX = /usr

--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -165,26 +165,19 @@ HEADERS += \
     types/config.h \
     types/accountpassword.h \
     types/affectedmessages.h
-
-linux {
-    contains(QMAKE_HOST.arch, x86_64) {
-        LIB_PATH = x86_64-linux-gnu
-    } else {
-        LIB_PATH = i386-linux-gnu
-    }
 }
 
 isEmpty(PREFIX) {
     PREFIX = /usr
 }
 
-INSTALL_PREFIX = $$PREFIX/include/libqtelegram-ae
+INSTALL_PREFIX = $$[QT_INSTALL_HEADERS]/libqtelegram-ae
 INSTALL_HEADERS = $$HEADERS
 include(qmake/headerinstall.pri)
 
 target = $$TARGET
 isEmpty(LIBDIR) {
-    target.path = $$PREFIX/lib/$$LIB_PATH
+    target.path = $$[QT_INSTALL_LIBS]
 } else {
     target.path = $$LIBDIR
 }


### PR DESCRIPTION
Instead of using special LIBDIR and HEADER on standard path is better to use Qt provided libs and header location
This guarantee that the library will be following the Qt which is compiled, and benefits of his ld path in Linux, so avoiding then the often confusion on 32/64 multilib installs.

I'm using by default this patches on Fedora  
