### PR TITLE
Fix include and lib install path

### DIFF
--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -166,14 +166,6 @@ HEADERS += \
     types/accountpassword.h \
     types/affectedmessages.h
 
-linux {
-    contains(QMAKE_HOST.arch, x86_64) {
-        LIB_PATH = x86_64-linux-gnu
-    } else {
-        LIB_PATH = i386-linux-gnu
-    }
-}
-
 INSTALL_PREFIX = $$[QT_INSTALL_HEADERS]/libqtelegram-ae
 INSTALL_HEADERS = $$HEADERS
 include(qmake/headerinstall.pri)

--- a/libqtelegram-ae.pro
+++ b/libqtelegram-ae.pro
@@ -174,17 +174,13 @@ linux {
     }
 }
 
-isEmpty(PREFIX) {
-    PREFIX = /usr
-}
-
-INSTALL_PREFIX = $$PREFIX/include/libqtelegram-ae
+INSTALL_PREFIX = $$[QT_INSTALL_HEADERS]/libqtelegram-ae
 INSTALL_HEADERS = $$HEADERS
 include(qmake/headerinstall.pri)
 
 target = $$TARGET
 isEmpty(LIBDIR) {
-    target.path = $$PREFIX/lib/$$LIB_PATH
+    target.path = $$[QT_INSTALL_LIBS]
 } else {
     target.path = $$LIBDIR
 }


### PR DESCRIPTION
This aligns libqtelegram-ae install paths with TelegramQML install paths. The benefit is also properly detected architecture.
