### PR TITLE
added virtual signature for destructors of classes that can be inherited

### DIFF
--- a/core/abstractapi.h
+++ b/core/abstractapi.h
@@ -33,7 +33,7 @@ class AbstractApi : public SessionManager
     Q_OBJECT
 public:
     explicit AbstractApi(Session *session, Settings *settings, CryptoUtils *crypto, QObject *parent = 0);
-    ~AbstractApi();
+    virtual ~AbstractApi();
 
 Q_SIGNALS:
     void updatesTooLong();

--- a/core/api.cpp
+++ b/core/api.cpp
@@ -216,6 +216,9 @@ Api::Api(Session *session, Settings *settings, CryptoUtils *crypto, QObject *par
     uploadGetFileMethods.onError = &Api::onUploadGetFileError;
 }
 
+Api::~Api() {
+}
+
 void Api::onError(Query *q, qint32 errorCode, const QString &errorText) {
     Q_EMIT error(q->msgId(), errorCode, errorText, q->name() );
 }

--- a/core/api.h
+++ b/core/api.h
@@ -70,6 +70,7 @@ class Api : public AbstractApi
     Q_OBJECT
 public:
     explicit Api(Session *session, Settings *settings, CryptoUtils *crypto, QObject *parent = 0);
+    virtual ~Api();
 
     // Registration / authorization
     qint64 helpGetConfig();

--- a/core/connection.h
+++ b/core/connection.h
@@ -38,7 +38,7 @@ class Connection : public QTcpSocket, public Endpoint
     Q_OBJECT
 public:
     explicit Connection(const QString &host = QString::null, qint32 port = -1, QObject *parent = 0);
-    ~Connection();
+    virtual ~Connection();
 
     void connectToServer();
 

--- a/core/endpoint.h
+++ b/core/endpoint.h
@@ -28,7 +28,7 @@ class Endpoint
 public:
     Endpoint() {}
     explicit Endpoint(const QString &host, qint32 port) : m_host(host), m_port(port) {}
-    ~Endpoint() {}
+    virtual ~Endpoint() {}
 
     QString host() const { return m_host; }
     qint32 port() const { return m_port; }

--- a/core/inboundpkt.cpp
+++ b/core/inboundpkt.cpp
@@ -35,6 +35,9 @@ InboundPkt::InboundPkt(char *buffer, qint32 length) :
     m_inEnd(m_inPtr + (m_length / 4)) {
 }
 
+InboundPkt::~InboundPkt() {
+}
+
 const char *InboundPkt::buffer() const{
     return m_buffer;
 }

--- a/core/inboundpkt.h
+++ b/core/inboundpkt.h
@@ -74,6 +74,7 @@ class InboundPkt
 {
 public:
     explicit InboundPkt(char* buffer, qint32 len);
+    virtual ~InboundPkt();
 
     virtual const char *buffer() const;
     virtual qint32 length() const;

--- a/core/sessionmanager.h
+++ b/core/sessionmanager.h
@@ -35,7 +35,7 @@ class SessionManager : public QObject
     Q_OBJECT
 public:
     explicit SessionManager(Session *session, Settings *settings, CryptoUtils *crypto, QObject *parent = 0);
-    ~SessionManager();
+    virtual ~SessionManager();
 
     void createMainSessionToDc(DC *dc);
     void changeMainSessionToDc(DC *dc);

--- a/secret/secretchat.cpp
+++ b/secret/secretchat.cpp
@@ -21,8 +21,7 @@
 
 Q_LOGGING_CATEGORY(TG_SECRET_SECRETCHAT, "tg.secret.secretchat")
 
-SecretChat::SecretChat(Settings *settings, QObject *parent) :
-    QObject(parent),
+SecretChat::SecretChat(Settings *settings) :
     mSettings(settings),
     mState(Init),
     mChatId(0),

--- a/secret/secretchat.h
+++ b/secret/secretchat.h
@@ -37,9 +37,8 @@
 Q_DECLARE_LOGGING_CATEGORY(TG_SECRET_SECRETCHAT)
 
 class Settings;
-class LIBQTELEGRAMSHARED_EXPORT SecretChat : public QObject
+class LIBQTELEGRAMSHARED_EXPORT SecretChat
 {
-    Q_OBJECT
 public:
 
     enum State {
@@ -51,7 +50,7 @@ public:
 
     typedef QMap<QPair<qint32,qint32>, qint64> Sequence;
 
-    explicit SecretChat(Settings *settings, QObject *parent = 0);
+    explicit SecretChat(Settings *settings);
     ~SecretChat();
 
     void createMyKey(const QByteArray &serverRandom);

--- a/secret/secretstate.cpp
+++ b/secret/secretstate.cpp
@@ -18,8 +18,7 @@
 #include "secretstate.h"
 #include "core/settings.h"
 
-SecretState::SecretState(Settings *settings, QObject *parent) :
-    QObject(parent),
+SecretState::SecretState(Settings *settings) :
     mSettings(settings),
     mVersion(0),
     mG(0),

--- a/secret/secretstate.h
+++ b/secret/secretstate.h
@@ -25,11 +25,10 @@
 #include "types/inputuser.h"
 #include "secretchat.h"
 
-class SecretState : public QObject
+class SecretState
 {
-    Q_OBJECT
 public:
-    explicit SecretState(Settings *settings, QObject *parent = 0);
+    explicit SecretState(Settings *settings);
     ~SecretState();
 
     qint32 version() { return mVersion; }

--- a/telegram.cpp
+++ b/telegram.cpp
@@ -80,9 +80,8 @@ Telegram::Telegram(const QString &defaultHostAddress, qint16 defaultHostPort, qi
     }
 
     mDcProvider = new DcProvider(mSettings, mCrypto);
-    mDcProvider->setParent(this);
 
-    mSecretState = new SecretState(mSettings, this);
+    mSecretState = new SecretState(mSettings);
     mEncrypter = new Encrypter(mSettings);
     mDecrypter = new Decrypter(mSettings);
 
@@ -354,7 +353,7 @@ void Telegram::onDcProviderReady() {
 qint64 Telegram::messagesCreateEncryptedChat(const InputUser &user) {
     qCDebug(TG_LIB_SECRET) << "creating new encrypted chat";
     // generate a new object where store all the needed secret chat data
-    SecretChat *secretChat = new SecretChat(mSettings, this);
+    SecretChat *secretChat = new SecretChat(mSettings);
     secretChat->setRequestedUser(user);
     return generateGAorB(secretChat);
 }
@@ -815,7 +814,7 @@ void Telegram::processSecretChatUpdate(const Update &update) {
 
             ASSERT(participantId == ourId());
 
-            SecretChat* secretChat = new SecretChat(mSettings, this);
+            SecretChat* secretChat = new SecretChat(mSettings);
             secretChat->setChatId(encryptedChat.id());
             secretChat->setAccessHash(encryptedChat.accessHash());
             secretChat->setDate(encryptedChat.date());


### PR DESCRIPTION
removed not needed QObject parent class for DcProvider and SecretChat
removed setting a QObject parent for DcProvider and SecretChat; this makes them be deleted in a proper order

All these changes should prevent segmentation fault problems when library shutdown. There was a previous problem related with this that was caused by having Telegram class as parent of DcProvider, so that DcProvider was deleted before some of its internal objects

NOTE: I tested this change along with other code that is not included here, so this should be tested again properly before landing
