### PR TITLE
Fix the reconnect problem when connection fail after the helpGetConfi…

### DIFF
--- a/core/dcprovider.h
+++ b/core/dcprovider.h
@@ -86,6 +86,9 @@ private:
     // is the reference for exporting data to any dc transfer auth receipt
     Session *mWorkingDcSession;
 
+    // In order to map getConfigRequests and sessions
+    QMap<Session*, qint64> mGetConfigRequests;
+
 
 private Q_SLOTS:
     void onDcReady(DC *dc);


### PR DESCRIPTION
Hi

It's a fix for the reconnect problem when connection fail after the helpGetConfig called and before the answer recieved.
It occured when server disconnect the socket after helpGetConfig called on the DcProvider::onApiReady. When It happened, reconnect operation couldn't work correctly.

I don't know it's a true fix or not. I tested it many times and it works without problem.
What is your idea?

Thank you :)
