### PR TITLE
Fix the reconnect problem when connection fail after the helpGetConfig called and before the answer recieved

### DIFF
--- a/core/dcprovider.cpp
+++ b/core/dcprovider.cpp
@@ -29,7 +29,8 @@ DcProvider::DcProvider(Settings *settings, CryptoUtils *crypto) :
     mApi(0),
     mPendingDcs(0),
     mPendingTransferSessions(0),
-    mWorkingDcSession(0) {
+    mWorkingDcSession(0),
+    mConfigReceived(0) {
 }
 
 DcProvider::~DcProvider() {
@@ -248,7 +249,7 @@ void DcProvider::onApiReady(DC*) {
             static_cast<Qt::ConnectionType>(Qt::AutoConnection | Qt::UniqueConnection) );
 
     qint64 rid = mApi->helpGetConfig();
-    mGetConfigRequests[session] = rid;
+    mGetConfigRequests[rid] = session;
 }
 
 void DcProvider::onConfigReceived(qint64 msgId, const Config &config) {
@@ -258,13 +259,14 @@ void DcProvider::onConfigReceived(qint64 msgId, const Config &config) {
     qCDebug(TG_CORE_DCPROVIDER) << "testMode =" << config.testMode();
     qCDebug(TG_CORE_DCPROVIDER) << "thisDc =" << config.thisDc();
 
-    Session *session = mGetConfigRequests.key(msgId);
-    if(!session)
+    Session *session = mGetConfigRequests.take(msgId);
+    if(session)
+        disconnect(session, SIGNAL(sessionReady(DC*)), this, SLOT(onApiReady(DC*)));
+
+    if(mConfigReceived)
         return;
 
-    mGetConfigRequests.remove(session);
-    disconnect(session, SIGNAL(sessionReady(DC*)), this, SLOT(onApiReady(DC*)));
-
+    mConfigReceived = true;
 
     const QList<DcOption> &dcOptions = config.dcOptions();
 

--- a/core/dcprovider.cpp
+++ b/core/dcprovider.cpp
@@ -245,8 +245,7 @@ void DcProvider::onApiReady(DC*) {
     disconnect(session, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(onApiError()));
 
     // get the config
-    connect(mApi, SIGNAL(config(qint64,const Config&)), this, SLOT(onConfigReceived(qint64,const Config&)),
-            static_cast<Qt::ConnectionType>(Qt::AutoConnection | Qt::UniqueConnection) );
+    connect(mApi, SIGNAL(config(qint64,const Config&)), this, SLOT(onConfigReceived(qint64,const Config&)), Qt::UniqueConnection );
 
     qint64 rid = mApi->helpGetConfig();
     mGetConfigRequests[rid] = session;

--- a/core/dcprovider.h
+++ b/core/dcprovider.h
@@ -87,7 +87,8 @@ private:
     Session *mWorkingDcSession;
 
     // In order to map getConfigRequests and sessions
-    QMap<Session*, qint64> mGetConfigRequests;
+    QMap<qint64, Session*> mGetConfigRequests;
+    bool mConfigReceived;
 
 
 private Q_SLOTS:

--- a/core/dcprovider.h
+++ b/core/dcprovider.h
@@ -86,6 +86,9 @@ private:
     // is the reference for exporting data to any dc transfer auth receipt
     Session *mWorkingDcSession;
 
+    // In order to map getConfigRequests and sessions
+    QMap<Session*, qint64> mGetConfigRequests;
+
 
 private Q_SLOTS:
     void onDcReady(DC *dc);


### PR DESCRIPTION
Hi

It's a fix for the reconnect problem when connection fail after the helpGetConfig called and before the answer recieved.
It occured when server disconnect the socket after helpGetConfig called on the DcProvider::onApiReady. When It happened, reconnect operation couldn't work correctly.

I don't know it's a true fix or not. I tested it many times and it works without problem.
What is your idea?

Thank you :)
