### PR TITLE
Modified initConnection() header 

### DIFF
--- a/core/outboundpkt.cpp
+++ b/core/outboundpkt.cpp
@@ -87,6 +87,10 @@ void OutboundPkt::appendData(const void *data, qint32 len) {
     m_packetPtr += len >> 2;
 }
 
+void OutboundPkt::appendOutboundPkt(OutboundPkt& other) {
+    appendInts(other.buffer(), other.length());
+}
+
 void OutboundPkt::appendInts (const qint32 *what, qint32 len) {
     Q_ASSERT(m_packetPtr + len <= m_packetBuffer + PACKET_BUFFER_SIZE);
     memcpy (m_packetPtr, what, len * 4);

--- a/core/outboundpkt.h
+++ b/core/outboundpkt.h
@@ -42,6 +42,7 @@ public:
     void forwardPtr(qint32 positions);
     void initConnection();
 
+    void appendOutboundPkt(OutboundPkt& other);
     void appendInts(const qint32 *what, qint32 len);
     void appendInt(qint32 x);
     void appendLong(qint64 x);

--- a/core/session.h
+++ b/core/session.h
@@ -46,8 +46,6 @@ public:
     qint64 sendQuery(OutboundPkt &outboundPkt, QueryMethods *methods, const QVariant &extra = QVariant(), const QString &name = QString());
 
     inline qint64 sessionId() { return m_sessionId; }
-    inline bool initConnectionNeeded() { return m_initConnectionNeeded; }
-    inline void setInitConnectionNeeded(bool initConnectionNeeded) { m_initConnectionNeeded = initConnectionNeeded; }
     inline qint64 clientLastMsgId() { return m_clientLastMsgId; }
     inline qint32 seqNo() { return m_seqNo; }
     inline void setSeqNo(qint32 seqNo) { m_seqNo = seqNo; }


### PR DESCRIPTION
Modified appeding initConnection() to OutboundPkg when operation is the first in a session. Now, that is prepended to the original package when checked it is the first operation in session and before sending. This way it has not to be repeated for every potential case this could happend, only set in Session.sendQuery() method once.
