### PR TITLE
Modified appeding initConnection() to OutboundPkg when operation is t…

### DIFF
--- a/core/api.cpp
+++ b/core/api.cpp
@@ -272,10 +272,6 @@ qint64 Api::helpGetConfig() {
     CHECK_SESSION
     DEBUG_FUNCTION
     OutboundPkt p(mSettings);
-    if (mMainSession->initConnectionNeeded()) {
-        p.initConnection();
-        mMainSession->setInitConnectionNeeded(false);
-    }
     Functions::Help::getConfig(&p);
     return mMainSession->sendQuery(p, &helpGetConfigMethods, QVariant(), __FUNCTION__ );
 }
@@ -289,10 +285,6 @@ qint64 Api::helpGetInviteText(const QString &langCode) {
     CHECK_SESSION
     DEBUG_FUNCTION
     OutboundPkt p(mSettings);
-    if (mMainSession->initConnectionNeeded()) {
-        p.initConnection();
-        mMainSession->setInitConnectionNeeded(false);
-    }
     Functions::Help::getInviteText(&p, langCode);
     return mMainSession->sendQuery(p, &helpGetInviteTextMethods, QVariant(), __FUNCTION__ );
 }
@@ -313,10 +305,6 @@ qint64 Api::authCheckPhone(const QString &phoneNumber) {
     CHECK_SESSION
     DEBUG_FUNCTION
     OutboundPkt p(mSettings);
-    if (mMainSession->initConnectionNeeded()) {
-        p.initConnection();
-        mMainSession->setInitConnectionNeeded(false);
-    }
     Functions::Auth::checkPhone(&p, phoneNumber);
     qint64 resultId = mMainSession->sendQuery(p, &authCheckPhoneMethods, QVariant(), __FUNCTION__ );
     Q_EMIT authCheckPhoneSent(resultId, phoneNumber);
@@ -456,10 +444,6 @@ qint64 Api::authImportAuthorization(qint32 id, const QByteArray &bytes) {
     CHECK_SESSION
     DEBUG_FUNCTION
     OutboundPkt p(mSettings);
-    if (mMainSession->initConnectionNeeded()) {
-        p.initConnection();
-        mMainSession->setInitConnectionNeeded(false);
-    }
     Functions::Auth::importAuthorization(&p, id, bytes);
     return mMainSession->sendQuery(p, &authImportAuthorizationMethods, QVariant(), __FUNCTION__ );
 }
@@ -1167,10 +1151,6 @@ qint64 Api::messagesReadHistory(const InputPeer &peer, qint32 maxId, qint32 offs
     CHECK_SESSION
     DEBUG_FUNCTION
     OutboundPkt p(mSettings);
-    if (mMainSession->initConnectionNeeded()) {
-        p.initConnection();
-        mMainSession->setInitConnectionNeeded(false);
-    }
     Functions::Messages::readHistory(&p, peer, maxId, offset);
     return mMainSession->sendQuery(p, &messagesReadHistoryMethods, QVariant(), __FUNCTION__ );
 }
@@ -1702,10 +1682,6 @@ void Api::onUploadSaveFilePartAnswer(Query *q, InboundPkt &inboundPkt) {
 qint64 Api::uploadSaveFilePart(Session *session, qint64 fileId, qint32 filePart, const QByteArray &bytes) {
     Q_ASSERT(session);
     OutboundPkt p(mSettings);
-    if (session->initConnectionNeeded()) {
-        p.initConnection();
-        session->setInitConnectionNeeded(false);
-    }
     Functions::Upload::saveFilePart(&p, fileId, filePart, bytes);
     QVariant extra = fileId;
     return session->sendQuery(p, &uploadSaveFilePartMethods, extra);
@@ -1719,10 +1695,6 @@ void Api::onUploadSaveBigFilePartAnswer(Query *q, InboundPkt &inboundPkt) {
 qint64 Api::uploadSaveBigFilePart(Session *session, qint64 fileId, qint32 filePart, qint32 fileTotalParts, const QByteArray &bytes) {
     Q_ASSERT(session);
     OutboundPkt p(mSettings);
-    if (session->initConnectionNeeded()) {
-        p.initConnection();
-        session->setInitConnectionNeeded(false);
-    }
     Functions::Upload::saveBigFilePart(&p, fileId, filePart, fileTotalParts, bytes);
     QVariant extra = fileId;
     return session->sendQuery(p, &uploadSaveBigFilePartMethods, extra);
@@ -1740,10 +1712,6 @@ void Api::onUploadGetFileAnswer(Query *q, InboundPkt &inboundPkt) {
 qint64 Api::uploadGetFile(Session *session, const InputFileLocation &location, qint32 offset, qint32 limit) {
     Q_ASSERT(session);
     OutboundPkt p(mSettings);
-    if (session->initConnectionNeeded()) {
-        p.initConnection();
-        session->setInitConnectionNeeded(false);
-    }
     Functions::Upload::getFile(&p, location, offset, limit);
     return session->sendQuery(p, &uploadGetFileMethods, QVariant(), __FUNCTION__ );
 }

--- a/core/outboundpkt.cpp
+++ b/core/outboundpkt.cpp
@@ -87,6 +87,10 @@ void OutboundPkt::appendData(const void *data, qint32 len) {
     m_packetPtr += len >> 2;
 }
 
+void OutboundPkt::appendOutboundPkt(OutboundPkt& other) {
+    appendInts(other.buffer(), other.length());
+}
+
 void OutboundPkt::appendInts (const qint32 *what, qint32 len) {
     Q_ASSERT(m_packetPtr + len <= m_packetBuffer + PACKET_BUFFER_SIZE);
     memcpy (m_packetPtr, what, len * 4);

--- a/core/outboundpkt.h
+++ b/core/outboundpkt.h
@@ -42,6 +42,7 @@ public:
     void forwardPtr(qint32 positions);
     void initConnection();
 
+    void appendOutboundPkt(OutboundPkt& other);
     void appendInts(const qint32 *what, qint32 len);
     void appendInt(qint32 x);
     void appendLong(qint64 x);

--- a/core/session.cpp
+++ b/core/session.cpp
@@ -508,6 +508,17 @@ qint64 Session::sendQuery(OutboundPkt &outboundPkt, QueryMethods *methods, const
     qint32 *data = outboundPkt.buffer();
     qint32 ints = outboundPkt.length();
 
+    // prepend init connection header to outboundPkt if initConnectionNeeded
+    // Note: 'wrap' needs to be declare outside of if to persist until encriptSendMessage is completed
+    OutboundPkt wrap(mSettings);
+    if (m_initConnectionNeeded) {
+        wrap.initConnection();
+        wrap.appendOutboundPkt(outboundPkt);
+        data = wrap.buffer();
+        ints = wrap.length();
+        m_initConnectionNeeded = false;
+    }
+
     qCDebug(TG_CORE_SESSION) << "Sending query of size" << 4 * ints << "to DC" << m_dc->id() << "at" << peerName() << ":" << peerPort() << "by session" << QString::number(m_sessionId, 16);
 
     Query *q = new Query(this);

--- a/core/session.h
+++ b/core/session.h
@@ -46,8 +46,6 @@ public:
     qint64 sendQuery(OutboundPkt &outboundPkt, QueryMethods *methods, const QVariant &extra = QVariant(), const QString &name = QString());
 
     inline qint64 sessionId() { return m_sessionId; }
-    inline bool initConnectionNeeded() { return m_initConnectionNeeded; }
-    inline void setInitConnectionNeeded(bool initConnectionNeeded) { m_initConnectionNeeded = initConnectionNeeded; }
     inline qint64 clientLastMsgId() { return m_clientLastMsgId; }
     inline qint32 seqNo() { return m_seqNo; }
     inline void setSeqNo(qint32 seqNo) { m_seqNo = seqNo; }


### PR DESCRIPTION
…he first in a session. Now, that is prepended to the original package when checked it is the first operation in session and before sending. This way it has not to be repeated for every potential case this could happend, only set in Session.sendQuery() method once.
