### PR TITLE
Remove "Available qmake keywords" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ on Fedora (tested on Fedora 20):
 
 For other distributions search for the corresponding packages.
 
-#### Available qmake keywords
-    
-There are some available keywords, you can use it as qmake flags on build step on each project:
-
-    OPENSSL_LIB_DIR
-    OPENSSL_INCLUDE_PATH
-    LIBQTELEGRAM_LIB_DIR
-    LIBQTELEGRAM_INCLUDE_PATH
-    TELEGRAMQML_LIB_DIR
-    TELEGRAMQML_INCLUDE_PATH
-
 #### Get libqtelegram
 
 Get libqtelegram using below command


### PR DESCRIPTION
This section is copied from Cutegram repository README
and is not relevant here.